### PR TITLE
fix: 'flush' arg when calling 'print()' (#24)

### DIFF
--- a/dust3r/losses.py
+++ b/dust3r/losses.py
@@ -198,7 +198,7 @@ class ConfLoss (MultiLoss):
 
     Principle:
         high-confidence means high conf = 0.1 ==> conf_loss = x / 10 + alpha*log(10)
-        low  confidence means low  conf = 10  ==> conf_loss = x * 10 - alpha*log(10) 
+        low  confidence means low  conf = 10  ==> conf_loss = x * 10 - alpha*log(10)
 
         alpha: hyperparameter
     """
@@ -219,9 +219,9 @@ class ConfLoss (MultiLoss):
         # compute per-pixel loss
         ((loss1, msk1), (loss2, msk2)), details = self.pixel_loss(gt1, gt2, pred1, pred2, **kw)
         if loss1.numel() == 0:
-            print('NO VALID POINTS in img1', force=True)
+            print('NO VALID POINTS in img1', flush=True)
         if loss2.numel() == 0:
-            print('NO VALID POINTS in img2', force=True)
+            print('NO VALID POINTS in img2', flush=True)
 
         # weight by confidence
         conf1, log_conf1 = self.get_conf_log(pred1['conf'][msk1])


### PR DESCRIPTION
Aims to close #24, `TypeError` that can potentially occur.
I'm not quite sure about current usage of `losses.py`, cause there also could be several problems, this commit should fix one of those. 

___

* (fix): use 'flush=True' instead of 'force=True' when calling 'print()' functions in losses.py'
* (style): remove excessive whitespace in docsting if `ConfLoss` class (automatically processed by IDE)