### PR TITLE
Fix: file path to the entry point

### DIFF
--- a/docker/files/cpu.Dockerfile
+++ b/docker/files/cpu.Dockerfile
@@ -32,7 +32,7 @@ RUN pip install opencv-python==4.8.0.74
 
 WORKDIR /dust3r
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/docker/files/cuda.Dockerfile
+++ b/docker/files/cuda.Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /dust3r/croco/models/curope/
 RUN python setup.py build_ext --inplace
 
 WORKDIR /dust3r
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT [ "./entrypoint.sh" ]


### PR DESCRIPTION
Running the demo with the command `bash run.sh --with-cuda --model-name="DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth"` resulted in the following error:

```bash
+ model_name=DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth
+ with_cuda=0
+ for arg in "$@"
+ case $arg in
+ with_cuda=1
+ for arg in "$@"
+ case $arg in
+ model_name=DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth
+ main
+ check_docker
+ command -v docker
+ download_model_checkpoint
+ '[' -f ./files/checkpoints/DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth ']'
+ echo 'Downloading model checkpoint DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth...'
Downloading model checkpoint DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth...
+ wget https://download.europe.naverlabs.com/ComputerVision/DUSt3R/DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth -P ./files/checkpoints
--2024-03-12 15:30:13--  https://download.europe.naverlabs.com/ComputerVision/DUSt3R/DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth
Resolving download.europe.naverlabs.com (download.europe.naverlabs.com)... 110.234.56.25
Connecting to download.europe.naverlabs.com (download.europe.naverlabs.com)|110.234.56.25|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2285019929 (2.1G)
Saving to: ‘./files/checkpoints/DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth’

DUSt3R_ViTLarge_BaseDecoder_5 100%[=================================================>]   2.13G  10.0MB/s    in 4m 0s

2024-03-12 15:34:13 (9.08 MB/s) - ‘./files/checkpoints/DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth’ saved [2285019929/2285019929]

+ set_dcomp
+ command -v docker-compose
+ dcomp=docker-compose
+ run_docker
+ export MODEL=DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth
+ MODEL=DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth
+ '[' 1 -eq 1 ']'
+ docker-compose -f docker-compose-cuda.yml up --build
[+] Building 215.7s (18/18) FINISHED                                                                     docker:default
 => [dust3r-demo internal] load build definition from cuda.Dockerfile                                              0.1s
 => => transferring dockerfile: 867B                                                                               0.0s
 => [dust3r-demo internal] load metadata for nvcr.io/nvidia/pytorch:24.01-py3                                      3.4s
 => [dust3r-demo auth] nvidia/pytorch:pull,push token for nvcr.io                                                  0.0s
 => [dust3r-demo internal] load .dockerignore                                                                      0.0s
 => => transferring context: 2B                                                                                    0.0s
 => CACHED [dust3r-demo  1/12] FROM nvcr.io/nvidia/pytorch:24.01-py3@sha256:afd682405d620a620f61f38cb9d9bbc6a5230  0.0s
 => [dust3r-demo internal] load build context                                                                      0.0s
 => => transferring context: 245B                                                                                  0.0s
 => [dust3r-demo  2/12] RUN apt-get update && apt-get install -y     git=1:2.34.1-1ubuntu1.10     libglib2.0-0=2  11.9s
 => [dust3r-demo  3/12] RUN git clone --recursive https://github.com/naver/dust3r /dust3r                          1.8s
 => [dust3r-demo  4/12] WORKDIR /dust3r                                                                            0.0s
 => [dust3r-demo  5/12] RUN pip install -r requirements.txt                                                       29.7s
 => [dust3r-demo  6/12] RUN pip install -r requirements_optional.txt                                               4.9s
 => [dust3r-demo  7/12] RUN pip install opencv-python==4.8.0.74                                                    8.1s
 => [dust3r-demo  8/12] WORKDIR /dust3r/croco/models/curope/                                                       0.0s
 => [dust3r-demo  9/12] RUN python setup.py build_ext --inplace                                                  154.4s
 => [dust3r-demo 10/12] WORKDIR /dust3r                                                                            0.0s
 => [dust3r-demo 11/12] COPY entrypoint.sh /entrypoint.sh                                                          0.0s
 => [dust3r-demo 12/12] RUN chmod +x /entrypoint.sh                                                                0.5s
 => [dust3r-demo] exporting to image                                                                               0.7s
 => => exporting layers                                                                                            0.7s
 => => writing image sha256:83ac00c3886ba840a574c6b4a5ecbff8a08cb2255ae9644d0a297b03330d29c3                       0.0s
 => => naming to docker.io/library/docker-dust3r-demo                                                              0.0s
[+] Running 2/2
 ✔ Network docker_default          Created                                                                         0.0s
 ✔ Container docker-dust3r-demo-1  Created                                                                         0.1s
Attaching to dust3r-demo-1
dust3r-demo-1  | exec /entrypoint.sh: no such file or directory
dust3r-demo-1 exited with code 1
```

## Fix

- Updated file path to the entrypoint in docker files
