### PR TITLE
 Update README.md with web UI url

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ cd docker
 bash run.sh --model-name="DUSt3R_ViTLarge_BaseDecoder_512_dpt.pth"
 ```
 
+Visit `http://127.0.0.1:7860/` for the started web UI.
+
 ![demo](assets/demo.jpg)
 
 ## Usage


### PR DESCRIPTION
The docker instructions lack the URL that points to the web UI. (given the port it's a non-trivial to guess).