### PR TITLE
don't default focal clip

### DIFF
--- a/dust3r/post_process.py
+++ b/dust3r/post_process.py
@@ -9,7 +9,7 @@ import torch
 from dust3r.utils.geometry import xy_grid
 
 
-def estimate_focal_knowing_depth(pts3d, pp, focal_mode='median', min_focal=0.5, max_focal=3.5):
+def estimate_focal_knowing_depth(pts3d, pp, focal_mode='median', min_focal=0., max_focal=np.inf):
     """ Reprojection method, for when the absolute depth is known:
         1) estimate the camera focal using a robust estimator
         2) reproject points onto true rays, minimizing a certain error


### PR DESCRIPTION
Focal clipping causes issues in scenes with zoomed in/zoomed out cameras, defaulting clipping seems bad.
Actually I'm not sure when you would ever want to clip, if you need to clip probably the estimate is wrong, probably better to raise warning or something?