### PR TITLE
Add library metadata to HF integration

### DIFF
--- a/dust3r/model.py
+++ b/dust3r/model.py
@@ -23,6 +23,9 @@ except Exception as e:
     has_hf_integration = False
 
     class PyTorchModelHubMixin:
+        def __init_subclass__(cls, *args, **kwargs) -> None:
+            return super().__init_subclass__()  # ignore lib metadata
+
         def from_pretrained(pretrained_model_name_or_path, **kw):
             raise NotImplementedError((f'Either {pretrained_model_name_or_path} is not a valid file or '
                                        'you are missing the optional huggingface_hub dependency'))
@@ -52,7 +55,13 @@ def load_model(model_path, device, verbose=True):
     return net.to(device)
 
 
-class AsymmetricCroCo3DStereo (CroCoNet, PyTorchModelHubMixin):
+class AsymmetricCroCo3DStereo (
+        CroCoNet,
+        PyTorchModelHubMixin,
+        library_name="dust3r",
+        repo_url="https://github.com/naver/dust3r",
+        tags=["image-to-3d"],
+    ):
     """ Two siamese encoders, followed by two decoders.
     The goal is to output 3d points directly, both images in view1's frame
     (hence the asymmetry).   


### PR DESCRIPTION
Follow-up PR after https://github.com/naver/dust3r/pull/78.

The HF integration allows to define high level metadata valid for all models pushed to the Hub. This allows a better discoverability as users can find the model based on tags (either library name or task). This PR aims at adding these metadata while ensuring the HF integration is still optional.

Please let me know if you have any questions!