### PR TITLE
fix init transform from str

### DIFF
--- a/dust3r/datasets/base/base_stereo_view_dataset.py
+++ b/dust3r/datasets/base/base_stereo_view_dataset.py
@@ -36,9 +36,9 @@ class BaseStereoViewDataset (EasyDataset):
         self.split = split
         self._set_resolutions(resolution)
 
-        self.transform = transform
         if isinstance(transform, str):
             transform = eval(transform)
+        self.transform = transform
 
         self.aug_crop = aug_crop
         self.seed = seed


### PR DESCRIPTION
The PR fixes incorrect initialization order when `transform` is a `string` in `dust3r/datasets/base/base_stereo_view_dataset.py`