### PR TITLE
Fix MegaDepth train/val split

### DIFF
--- a/dust3r/datasets/megadepth.py
+++ b/dust3r/datasets/megadepth.py
@@ -14,7 +14,7 @@ from dust3r.utils.image import imread_cv2
 
 
 class MegaDepth(BaseStereoViewDataset):
-    def __init__(self, *args, split, ROOT, **kwargs):
+    def __init__(self, *args, ROOT, **kwargs):
         self.ROOT = ROOT
         super().__init__(*args, **kwargs)
         self.loaded_data = self._load_data(self.split)


### PR DESCRIPTION
The `__init__()` function of the MegaDepth data loader has a `split` parameter. However, it never gets passed to the super initializer and so `self.split` never gets set. This means `self.split` is always `None` for the MegaDepth dataset and training data = validation data.

https://github.com/naver/dust3r/blob/4c24a6ebf04809f2cfe59915e51779c8984aaa40/dust3r/datasets/megadepth.py#L16-L29