### PR TITLE
Fix: Remove deprecated css argument from Blocks() for Gradio 4–6 compatibility

### DIFF
--- a/dust3r/demo.py
+++ b/dust3r/demo.py
@@ -210,7 +210,7 @@ def set_scenegraph_options(inputfiles, winsize, refid, scenegraph_type):
 def main_demo(tmpdirname, model, device, image_size, server_name, server_port, silent=False):
     recon_fun = functools.partial(get_reconstructed_scene, tmpdirname, model, device, silent, image_size)
     model_from_scene_fun = functools.partial(get_3D_model_from_scene, tmpdirname, silent)
-    with gradio.Blocks(css=""".gradio-container {margin: 0 !important; min-width: 100%};""", title="DUSt3R Demo") as demo:
+    with gradio.Blocks(title="DUSt3R Demo") as demo:
         # scene state is save so that you can change conf_thr, cam_size... without rerunning the inference
         scene = gradio.State(None)
         gradio.HTML('<h2 style="text-align: center;">DUSt3R Demo</h2>')
@@ -284,4 +284,4 @@ def main_demo(tmpdirname, model, device, image_size, server_name, server_port, s
                                     inputs=[scene, min_conf_thr, as_pointcloud, mask_sky,
                                             clean_depth, transparent_cams, cam_size],
                                     outputs=outmodel)
-    demo.launch(share=False, server_name=server_name, server_port=server_port)
+    demo.launch(share=False, server_name=server_name, server_port=server_port, css=""".gradio-container {margin: 0 !important; min-width: 100%};""")


### PR DESCRIPTION
### Summary

This PR fixes a compatibility issue with newer Gradio versions (>= 4.x).

In `main_demo`, `gradio.Blocks` is currently called with a `css` keyword argument:

```python
with gradio.Blocks(css=""".gradio-container {margin: 0 !important; min-width: 100%};""", title="DUSt3R Demo") as demo:
```
In Gradio>=4, `Blocks` no longer accepts a `css` keyword, which results in:
> TypeError: BlockContext.init() got an unexpected keyword argument 'css'

### Fix

The fix simply moves the `css` argument from the `Blocks` constructor to `demo.launch`, which is supported in both Gradio 3 and >=4:
```python
with gradio.Blocks(title="DUSt3R Demo") as demo:
    ...
demo.launch(
    share=False,
    server_name=server_name,
    server_port=server_port,
    css=""".gradio-container {margin: 0 !important; min-width: 100%};""",
)

```
### Notes

Tested locally with:

- Python 3.11  
- torch 2.5.1
- gradio 6.0.1 

This change remains backward-compatible with Gradio 3.x and 4.x, because the `launch(css=...)` argument is supported across versions, while `css=` in `Blocks()` has been removed in Gradio 4+.

